### PR TITLE
adds fix where isEmpty was undefined in it's context.

### DIFF
--- a/app/javascript/packs/test/Validstate.test.js
+++ b/app/javascript/packs/test/Validstate.test.js
@@ -7,6 +7,7 @@ test('checks if value is required', () => {
   expect(Validstate.required(undefined)).toBe(false);
   expect(Validstate.required([])).toBe(false);
   expect(Validstate.required({})).toBe(false);
+  expect(Validstate.required({foo: '', bar: 'I have content'})).toBe(true);
   expect(Validstate.required(NaN)).toBe(false);
   expect(Validstate.required('I am required')).toBe(true);
 });

--- a/app/javascript/packs/validstate/Validstate.js
+++ b/app/javascript/packs/validstate/Validstate.js
@@ -254,9 +254,9 @@ export default class Validstate {
   * @returns {boolean}
   */
   isEmpty(value){
+    let _self = this;
     var isEmptyObject = function(a) {
       if (typeof a.length === 'undefined') { // it's an Object, not an Array
-        let _self = this;
         var hasNonempty = Object.keys(a).some(function nonEmpty(element){
           return !_self.isEmpty(a[element]);
         });
@@ -264,7 +264,7 @@ export default class Validstate {
       }
 
       return !a.some(function nonEmpty(element) { // check if array is really not empty as JS thinks
-        return !isEmpty(element); // at least one element should be non-empty
+        return !_self.isEmpty(element); // at least one element should be non-empty
       });
     };
     return (


### PR DESCRIPTION
Had to move _self higher in the context to make it relevant. This PR will fix the undefined method errors.


However, I also have some concerns about the breadth of this method. While it does look for empty elements. an object such as `{foo: ''}` is not considered empty and would cause the required option to return true. Seems like this method should also check the value as well.. thoughts?